### PR TITLE
Update to key Schedule

### DIFF
--- a/draft-ietf-tls-extended-key-update.md
+++ b/draft-ietf-tls-extended-key-update.md
@@ -4,6 +4,7 @@ title: Extended Key Update for Transport Layer Security (TLS) 1.3
 abbrev: Extended Key Update for TLS
 docname: draft-ietf-tls-extended-key-update-latest
 category: std
+updates: 9261, 8446
 
 ipr: trust200902
 submissiontype: IETF
@@ -645,8 +646,9 @@ hash value for the next generation is computed as follows:
 
 Once transcript_hash_N+1 has been computed, transcript_hash_N can be deleted.
 No prior transcript hash values need to be retained for future EKU exchanges.
-transcript_hash_0 denotes the transcript hash of the TLS handshake messages prior
-to the first EKU exchange.
+transcript_hash_0 denotes the transcript hash of the initial TLS handshake,
+covering all messages from the ClientHello up to and including the
+client Finished message.
 
 The following diagram shows the key derivation hierarchy.
 
@@ -875,18 +877,27 @@ Exported Authenticators {{!RFC9261}}.
 
 ## Post-Handshake Certificate-Based Client Authentication
 
-When Post-handshake Certificate-Based Client Authentication (Section 4.6.2 of {{TLS}})
-is performed after an Extended Key Update is complete, it produces a Finished message
-computed using the application traffic keys of the new epoch. This confirms that both peers
-are operating with the same updated traffic keys and completes an authenticated
-transition after the EKU.
+When Post-Handshake Certificate-Based Client Authentication (Section 4.6.2 of {{TLS}}) is
+performed after an Extended Key Update (EKU) is complete, the Handshake Context used for
+the transcript hash is updated. It consists of transcript_hash_N+1 concatenated
+with the CertificateRequest message. The Finished message is computed using a
+MAC key derived from the Base Key of the new epoch (client_application_traffic_secret_N+1).
+This confirms that both peers are operating with the same updated traffic keys
+and completes an authenticated transition after the EKU.
+
+To prevent cryptographic state ambiguity, the following constraints apply:
+
+* A TLS server MUST NOT initiate a post-handshake CertificateRequest while an EKU
+  exchange is in progress.
+* If a CertificateRequest has been sent but the corresponding Finished message has not
+  yet been received, the peers MUST NOT initiate an EKU exchange.
 
 ## Exported Authenticators
 
 This document updates Section 5.1 of {{!RFC9261}} to specify that, after an
 Extended Key Update has completed, the Handshake Context and Finished MAC Key used for
-Exported Authenticators can be derived from the exporter secret associated with the current epoch.
-Implementations that support the epoch-aware Exported Authenticators interface will have to provide a means
+Exported Authenticators MUST be derived from the exporter secret associated with the current epoch.
+Implementations that support the epoch-aware Exported Authenticators interface MUST provide a means
 for applications to request the generation or validation of Exported Authenticators using
 the exporter secret for a specific epoch.
 


### PR DESCRIPTION
This change updates the EKU key schedule to explicitly incorporate a transcript hash into EKU secret derivation. Previously, main_secret_N+1 was derived by recursively chaining from main_secret_N, which provides continuity but does not explicitly preserve transcript agreement.  It complicates the security proof for EKU.